### PR TITLE
Support new FTP structure + output directory

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core
+          pip install nf-core==2.5.0
 
       - name: Run nf-core lint
         env:

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -12,6 +12,7 @@ lint:
     - .github/workflows/awsfulltest.yml
   files_unchanged:
     - LICENSE
+    - .gitattributes
     - .github/CONTRIBUTING.md
     - .github/ISSUE_TEMPLATE/bug_report.yml
     - .github/workflows/linting.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Minor bugfix update.
 
 - When a samplesheet is provided, do not process the individual command-line parameters
 
-
 ## v1.0.0 - [2022-10-07]
 
 Initial release of sanger-tol/ensemblgenedownload, created with the [nf-core](https://nf-co.re/) template.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ On release, automated continuous integration tests run the pipeline on a full-si
 
 ## Overview
 
-The pipeline takes a CSV file that contains assembly accession number, Ensembl species names (as they may differ from Tree of Life ones !), output directories, and geneset versions.
+The pipeline takes a CSV file that contains assembly accession number, Ensembl species names (as they may differ from Tree of Life ones !), output directories, geneset methods and geneset versions.
 Assembly accession numbers are optional. If missing, the pipeline assumes it can be retrieved from files named `ACCESSION` in the standard location on disk.
 The pipeline downloads the Fasta files of the genes (cdna, cds, and protein sequences) as well as the GFF3 file.
 All files are compressed with `bgzip`, and indexed with `samtools faidx` or `tabix`.

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,6 +1,5 @@
-species_dir,assembly_name,assembly_accession,ensembl_species_name,geneset_version
-25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,2020_11
-25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,2022_03
-25g/data/insects/Osmia_bicornis,iOsmBic2.1,GCA_907164935.1,Osmia_bicornis_bicornis,2021_11
-25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,2022_02
-darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,2022_03
+species_dir,assembly_name,assembly_accession,ensembl_species_name,annotation_method,geneset_version
+25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq,2020_11
+25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq,2022_03
+25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,ensembl,2022_02
+darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,braker,2022_03

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -25,14 +25,19 @@
             "ensembl_species_name": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "errorMessage": "Name of the species, as used in the Ensembl FTP"
+                "errorMessage": "The (Ensembl) species name must be provided and cannot contain spaces"
+            },
+            "annotation_method": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "The annotation method must be provided and cannot contain spaces"
             },
             "geneset_version": {
                 "type": "string",
                 "pattern": "^20[0-9]{2}_[01][0-9]$",
-                "errorMessage": "Version of the geneset, usually in the form `YYYY-MM`."
+                "errorMessage": "The version of the geneset must be in the form `YYYY-MM`."
             }
         },
-        "required": ["species_dir", "assembly_name", "ensembl_species_name", "geneset_version"]
+        "required": ["species_dir", "assembly_name", "ensembl_species_name", "annotation_method", "geneset_version"]
     }
 }

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -32,6 +32,7 @@ class RowChecker:
         name_col="assembly_name",
         accession_col="assembly_accession",
         ensembl_name_col="ensembl_species_name",
+        method_col="annotation_method",
         geneset_col="geneset_version",
         **kwargs,
     ):
@@ -47,6 +48,8 @@ class RowChecker:
                 number (default "assembly_accession").
             ensembl_name_col(str): The name of the column that contains the Ensembl species name
                 (default "ensembl_species_name").
+            annotation_method (str): The name of the column that contains the annotation method
+                (default "annotation_method").
             geneset_col (str): The name of the column that contains the geneset version
                 (default "geneset_version").
 
@@ -56,6 +59,7 @@ class RowChecker:
         self._name_col = name_col
         self._accession_col = accession_col
         self._ensembl_name_col = ensembl_name_col
+        self._method_col = method_col
         self._geneset_col = geneset_col
         self._seen = set()
         self.modified = []
@@ -75,8 +79,9 @@ class RowChecker:
         self._validate_name(row)
         self._validate_accession(row)
         self._validate_ensembl_name(row)
+        self._validate_method(row)
         self._validate_geneset(row)
-        self._seen.add((row[self._name_col], row[self._geneset_col]))
+        self._seen.add((row[self._name_col], row[self._method_col], row[self._geneset_col]))
         self.modified.append(row)
 
     def _validate_dir(self, row):
@@ -108,6 +113,13 @@ class RowChecker:
             raise AssertionError("Ensembl name is required.")
         if " " in row[self._ensembl_name_col]:
             raise AssertionError("Ensembl names must not contain whitespace.")
+
+    def _validate_method(self, row):
+        """Assert that the annotation method is non-empty and has no space."""
+        if not row[self._method_col]:
+            raise AssertionError("Annotation method is required.")
+        if " " in row[self._method_col]:
+            raise AssertionError("Annotation methods must not contain whitespace.")
 
     def _validate_geneset(self, row):
         """Assert that the geneset version matches the expected nomenclature."""
@@ -174,14 +186,15 @@ def check_samplesheet(file_in, file_out):
     Example:
         This function checks that the samplesheet follows the following structure::
 
-            species_dir,assembly_name,ensembl_species_name,geneset_version
-            25g/data/echinoderms/Asterias_rubens,eAstRub1.3,Asterias_rubens,2020_11
+            species_dir,assembly_name,ensembl_species_name,annotation_method,geneset_version
+            25g/data/echinoderms/Asterias_rubens,eAstRub1.3,Asterias_rubens,ensembl,2020_11
 
     """
     required_columns = {
         "species_dir",
         "assembly_name",
         "ensembl_species_name",
+        "annotation_method",
         "geneset_version",
     }
     # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -81,7 +81,9 @@ class RowChecker:
         self._validate_ensembl_name(row)
         self._validate_method(row)
         self._validate_geneset(row)
-        self._seen.add((row[self._name_col], row[self._method_col], row[self._geneset_col]))
+        self._seen.add(
+            (row[self._name_col], row[self._method_col], row[self._geneset_col])
+        )
         self.modified.append(row)
 
     def _validate_dir(self, row):

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,6 +20,7 @@ params {
     max_time   = '6.h'
 
     ensembl_species_name = "Osmia_bicornis_bicornis"
-    assembly_accession   = "GCA_907164935.1"
-    geneset_version      = "2021_11"
+    assembly_accession   = "GCA_907164925.1"
+    annotation_method    = "ensembl"
+    geneset_version      = "2022_02"
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -30,32 +30,33 @@ Here are the files you can expect in the `gene/` sub-directory.
 └── analysis
     └── ilNocFimb1.1
         └── gene
-            └── braker2
-                ├── GCA_905163415.1.braker2.2022_03.cdna.fa.gz
-                ├── GCA_905163415.1.braker2.2022_03.cdna.fa.gz.dict
-                ├── GCA_905163415.1.braker2.2022_03.cdna.fa.gz.fai
-                ├── GCA_905163415.1.braker2.2022_03.cdna.fa.gz.gzi
-                ├── GCA_905163415.1.braker2.2022_03.cdna.seq_length.tsv
-                ├── GCA_905163415.1.braker2.2022_03.cds.fa.gz
-                ├── GCA_905163415.1.braker2.2022_03.cds.fa.gz.dict
-                ├── GCA_905163415.1.braker2.2022_03.cds.fa.gz.fai
-                ├── GCA_905163415.1.braker2.2022_03.cds.fa.gz.gzi
-                ├── GCA_905163415.1.braker2.2022_03.cds.seq_length.tsv
-                ├── GCA_905163415.1.braker2.2022_03.gff3.gz
-                ├── GCA_905163415.1.braker2.2022_03.gff3.gz.csi
-                ├── GCA_905163415.1.braker2.2022_03.gff3.gz.gzi
-                ├── GCA_905163415.1.braker2.2022_03.pep.fa.gz
-                ├── GCA_905163415.1.braker2.2022_03.pep.fa.gz.dict
-                ├── GCA_905163415.1.braker2.2022_03.pep.fa.gz.fai
-                ├── GCA_905163415.1.braker2.2022_03.pep.fa.gz.gzi
-                └── GCA_905163415.1.braker2.2022_03.pep.seq_length.tsv
+            └── braker
+                ├── GCA_905163415.1.braker.2022_03.cdna.fa.gz
+                ├── GCA_905163415.1.braker.2022_03.cdna.fa.gz.dict
+                ├── GCA_905163415.1.braker.2022_03.cdna.fa.gz.fai
+                ├── GCA_905163415.1.braker.2022_03.cdna.fa.gz.gzi
+                ├── GCA_905163415.1.braker.2022_03.cdna.seq_length.tsv
+                ├── GCA_905163415.1.braker.2022_03.cds.fa.gz
+                ├── GCA_905163415.1.braker.2022_03.cds.fa.gz.dict
+                ├── GCA_905163415.1.braker.2022_03.cds.fa.gz.fai
+                ├── GCA_905163415.1.braker.2022_03.cds.fa.gz.gzi
+                ├── GCA_905163415.1.braker.2022_03.cds.seq_length.tsv
+                ├── GCA_905163415.1.braker.2022_03.gff3.gz
+                ├── GCA_905163415.1.braker.2022_03.gff3.gz.csi
+                ├── GCA_905163415.1.braker.2022_03.gff3.gz.gzi
+                ├── GCA_905163415.1.braker.2022_03.pep.fa.gz
+                ├── GCA_905163415.1.braker.2022_03.pep.fa.gz.dict
+                ├── GCA_905163415.1.braker.2022_03.pep.fa.gz.fai
+                ├── GCA_905163415.1.braker.2022_03.pep.fa.gz.gzi
+                └── GCA_905163415.1.braker.2022_03.pep.seq_length.tsv
 ```
 
 The directory structure includes the assembly name, e.g. `fParRan2.2`, and all files are named after the assembly accession, e.g. `GCA_900634625.2`.
-The file name (and the directory name) includes the annotation method and date. Current methods are:
+The file name (and the directory name) includes the annotation method and date. Current methods include:
 
-- `braker2` for [BRAKER2](https://academic.oup.com/nargab/article/3/1/lqaa108/6066535)
 - `ensembl` for Ensembl's own annotation pipeline
+- `braker` for [BRAKER2](https://academic.oup.com/nargab/article/3/1/lqaa108/6066535)
+- `refseq` for [RefSeq](https://academic.oup.com/nar/article/49/D1/D1020/6018440)
 
 The `.seq_length.tsv` files are tabular analogous to the common `chrom.sizes`. They contain the sequence names and their lengths.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,7 +30,7 @@ work                # Directory containing the nextflow working files
 
 ## Bulk download
 
-To download multiple datasets at once, descrbe these in a "samplesheet": a comma-separated files that lists the command-line arguments.
+To download multiple datasets at once, describe these in a "samplesheet": a comma-separated files that lists the command-line arguments.
 
 ```bash
 --input '[path to samplesheet file]'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,23 +19,9 @@ The pipeline accepts command-one line arguments to specify a single genome to do
 nextflow run sanger-tol/ensemblgenedownload -profile singularity --ensembl_species_name Noctua_fimbriata --assembly_accession GCA_905163415.1 --annotation_method braker --geneset_version 2022_03 --outdir results
 ```
 
-Note that the pipeline will create the following files in your working directory:
-
-```bash
-work                # Directory containing the nextflow working files
-<OUTDIR>            # Finished results in specified location (defined with --outdir)
-.nextflow_log       # Log file from Nextflow
-# Other nextflow hidden files, eg. history of pipeline runs and old logs.
-```
-
 ## Bulk download
 
 To download multiple datasets at once, describe these in a "samplesheet": a comma-separated files that lists the command-line arguments.
-
-```bash
---input '[path to samplesheet file]'
-```
-
 The file must have five columns, but accepts six as in the [example samplesheet](../assets/samplesheet.csv) provided with the pipeline and pasted here:
 
 ```console
@@ -61,6 +47,21 @@ A samplesheet may contain:
 - multiple datasets of the same species
 - multiple datasets of the same assembly
 - multiple datasets in the same output directory
+
+```bash
+nextflow run sanger-tol/ensemblgenedownload -profile singularity --input samplesheet.csv --outdir results
+```
+
+## Running the pipeline
+
+Note that the pipeline will create the following files in your working directory:
+
+```bash
+work                # Directory containing the nextflow working files
+<OUTDIR>            # Finished results in specified location (defined with --outdir)
+.nextflow_log       # Log file from Nextflow
+.nextflow           # Directory where Nextflow keeps track of jobs
+```
 
 ### Updating the pipeline
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,11 +11,12 @@ The pipeline accepts command-one line arguments to specify a single genome to do
 
 - `--ensembl_species_name`: How Ensembl name the species (as it can be different from Tree of Life),
 - `--assembly_accession`: The accession number of the assembly,
+- `--annotation_method`: The annotation method of the geneset,
 - `--geneset_version`: The geneset version to download,
 - `--outdir`: Where to download the data.
 
 ```console
-nextflow run sanger-tol/ensemblgenedownload -profile singularity --ensembl_species_name Noctua_fimbriata --assembly_accession GCA_905163415.1 --geneset_version 2022_03 --outdir results
+nextflow run sanger-tol/ensemblgenedownload -profile singularity --ensembl_species_name Noctua_fimbriata --assembly_accession GCA_905163415.1 --annotation_method braker --geneset_version 2022_03 --outdir results
 ```
 
 Note that the pipeline will create the following files in your working directory:
@@ -35,15 +36,15 @@ To download multiple datasets at once, descrbe these in a "samplesheet": a comma
 --input '[path to samplesheet file]'
 ```
 
-The file must have four columns, but accepts five as in the [example samplesheet](../assets/samplesheet.csv) provided with the pipeline and pasted here:
+The file must have five columns, but accepts six as in the [example samplesheet](../assets/samplesheet.csv) provided with the pipeline and pasted here:
 
 ```console
-species_dir,assembly_name,assembly_accession,ensembl_species_name,geneset_version
-25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,2020_11
-25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,2022_03
-25g/data/insects/Osmia_bicornis,iOsmBic2.1,GCA_907164935.1,Osmia_bicornis_bicornis,2021_11
-25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,2022_02
-darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,2022_03
+
+species_dir,assembly_name,assembly_accession,ensembl_species_name,annotation_method,geneset_version
+25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq,2020_11
+25g/data/echinoderms/Asterias_rubens,eAstRub1.3,GCA_902459465.3,Asterias_rubens,refseq,2022_03
+25g/data/insects/Osmia_bicornis,iOsmBic2.1_alternate_haplotype,GCA_907164925.1,Osmia_bicornis_bicornis,ensembl,2022_02
+darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbriata,braker,2022_03
 ```
 
 | Column                 | Description                                                                                                                                                |
@@ -52,6 +53,7 @@ darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbria
 | `assembly_name`        | Name of the assembly. Used to build the actual output directory.                                                                                           |
 | `assembly_accession`   | (Optional). Accession number of the assembly to download. Typically of the form `GCA_*.*`. If missing, the pipeline will infer it from the ACCESSION file. |
 | `ensembl_species_name` | Name of the species, _as used by Ensembl_. Note: it may differ from Tree of Life's                                                                         |
+| `annotation_method`    | Name of the method of the geneset.                                                                                                                         |
 | `geneset_version`      | Version of the geneset, usually in the form `YYYY-MM`.                                                                                                     |
 
 A samplesheet may contain:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,7 @@ darwin/data/insects/Noctua_fimbriata,ilNocFimb1.1,GCA_905163415.1,Noctua_fimbria
 
 | Column                 | Description                                                                                                                                                |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `species_dir`          | Output directory for this species (evaluated from the current directory if a relative path). Analysis results are deposited in `analysis/$assembly_name/`. |
+| `species_dir`          | Output directory for this species (evaluated from `--outdir` if a relative path). Analysis results are deposited in `analysis/$assembly_name/`.            |
 | `assembly_name`        | Name of the assembly. Used to build the actual output directory.                                                                                           |
 | `assembly_accession`   | (Optional). Accession number of the assembly to download. Typically of the form `GCA_*.*`. If missing, the pipeline will infer it from the ACCESSION file. |
 | `ensembl_species_name` | Name of the species, _as used by Ensembl_. Note: it may differ from Tree of Life's                                                                         |

--- a/lib/NfcoreTemplate.groovy
+++ b/lib/NfcoreTemplate.groovy
@@ -228,7 +228,7 @@ class NfcoreTemplate {
             ${colors.blue} | (___   __ _ _ __   __ _  ___ _ __ ${colors.reset}______${colors.green}| |${colors.yellow} ___ ${colors.red}| |${colors.reset}
             ${colors.blue}  \\___ \\ / _` | '_ \\ / _` |/ _ \\ '__|${colors.reset}______${colors.green}| |${colors.yellow}/ _ \\${colors.red}| |${colors.reset}
             ${colors.blue}  ____) | (_| | | | | (_| |  __/ |         ${colors.green}| |${colors.yellow} (_) ${colors.red}| |____${colors.reset}
-            ${colors.blue} |_____/ \\__,_|_| |_|\\__, |\\___|_|         ${colors.green}|_|${colors.yellow}\\___/${colors.red}}|______|${colors.reset}
+            ${colors.blue} |_____/ \\__,_|_| |_|\\__, |\\___|_|         ${colors.green}|_|${colors.yellow}\\___/${colors.red}|______|${colors.reset}
             ${colors.blue}                      __/ |${colors.reset}
             ${colors.blue}                     |___/${colors.reset}
             ${colors.purple}  ${workflow.manifest.name} v${workflow.manifest.version}${colors.reset}

--- a/lib/WorkflowEnsemblgenedownload.groovy
+++ b/lib/WorkflowEnsemblgenedownload.groovy
@@ -17,8 +17,8 @@ class WorkflowEnsemblgenedownload {
                 System.exit(1)
             }
         } else {
-            if (!params.assembly_accession || !params.ensembl_species_name || !params.geneset_version || !params.outdir) {
-                log.error "Either --input, or --assembly_accession, --assembly_name, --geneset_version, and --outdir must be provided"
+            if (!params.assembly_accession || !params.ensembl_species_name || !params.annotation_method || !params.geneset_version || !params.outdir) {
+                log.error "Either --input, or --assembly_accession, --assembly_name, --annotation_method, --geneset_version, and --outdir must be provided"
                 System.exit(1)
             }
         }

--- a/lib/WorkflowEnsemblgenedownload.groovy
+++ b/lib/WorkflowEnsemblgenedownload.groovy
@@ -17,10 +17,14 @@ class WorkflowEnsemblgenedownload {
                 System.exit(1)
             }
         } else {
-            if (!params.assembly_accession || !params.ensembl_species_name || !params.annotation_method || !params.geneset_version || !params.outdir) {
-                log.error "Either --input, or --assembly_accession, --assembly_name, --annotation_method, --geneset_version, and --outdir must be provided"
+            if (!params.assembly_accession || !params.ensembl_species_name || !params.annotation_method || !params.geneset_version) {
+                log.error "Either --input, or --assembly_accession, --assembly_name, --annotation_method, and --geneset_version must be provided"
                 System.exit(1)
             }
+        }
+        if (!params.outdir) {
+            log.error "--outdir is mandatory"
+            System.exit(1)
         }
     }
 

--- a/modules/local/ensembl_geneset_download.nf
+++ b/modules/local/ensembl_geneset_download.nf
@@ -14,11 +14,11 @@ process ENSEMBL_GENESET_DOWNLOAD {
     tuple val(meta), val(ftp_path), val(remote_filename_stem)
 
     output:
-    tuple val(meta), env(ANNOTATION_METHOD), path("*-cdna.fa")    , emit: cdna
-    tuple val(meta), env(ANNOTATION_METHOD), path("*-cds.fa")     , emit: cds
-    tuple val(meta), env(ANNOTATION_METHOD), path("*-genes.gff3") , emit: gff
-    tuple val(meta), env(ANNOTATION_METHOD), path("*-pep.fa")     , emit: pep
-    path  "versions.yml"                                          , emit: versions
+    tuple val(meta), path("*-cdna.fa")    , emit: cdna
+    tuple val(meta), path("*-cds.fa")     , emit: cds
+    tuple val(meta), path("*-genes.gff3") , emit: gff
+    tuple val(meta), path("*-pep.fa")     , emit: pep
+    path  "versions.yml"                  , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -40,12 +40,6 @@ process ENSEMBL_GENESET_DOWNLOAD {
         md5sum -c md5checksums_restricted.txt
     fi
     gunzip *.gz
-    if head -n 1 ${remote_filename_stem}-pep.fa | grep '^>BRAKER'
-    then
-        ANNOTATION_METHOD=braker2
-    else
-        ANNOTATION_METHOD=ensembl
-    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,7 @@ params {
     input                      = null
     assembly_accession         = null
     ensembl_species_name       = null
+    annotation_method          = null
     geneset_version            = null
     ftp_root                   = "https://ftp.ensembl.org/pub/rapid-release/species"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ params {
     ftp_root                   = "https://ftp.ensembl.org/pub/rapid-release/species"
 
     // Boilerplate options
-    outdir                     = null
+    outdir                     = 'results'
     tracedir                   = "${params.outdir}/pipeline_info"
     publish_dir_mode           = 'copy'
     email                      = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -21,6 +21,7 @@
                 "ensembl_species_name": {
                     "type": "string",
                     "description": "Name of the species, _as used by Ensembl_. Note: it may differ from Tree of Life's",
+                    "pattern": "^\\S+$",
                     "fa_icon": "fas fa-italic"
                 },
                 "annotation_method": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -39,7 +39,8 @@
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",
-                    "description": "The output directory where the results will be saved. Not considered when running the pipeline with a .csv file as input.",
+                    "description": "The output directory where the results will be saved. Not considered for sample-sheet entries that have an absolute path.",
+                    "default": "results",
                     "fa_icon": "fas fa-folder-open"
                 },
                 "input": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -23,6 +23,12 @@
                     "description": "Name of the species, _as used by Ensembl_. Note: it may differ from Tree of Life's",
                     "fa_icon": "fas fa-italic"
                 },
+                "annotation_method": {
+                    "type": "string",
+                    "description": "Method used to annotate the genome. Typically `ensembl`, `braker`, etc.",
+                    "pattern": "^\\S+$",
+                    "fa_icon": "fas fa-book"
+                },
                 "geneset_version": {
                     "type": "string",
                     "description": "Version of the geneset, usually in the form `YYYY-MM`.",
@@ -42,7 +48,7 @@
                     "pattern": "^\\S+\\.csv$",
                     "schema": "assets/schema_input.json",
                     "description": "Path to comma-separated file containing information about the genesets to download. Used for bulk download of many genesets.",
-                    "help_text": "The file has to be a comma-separated file with fivecolumns, and a header row. The columns names must be `species_dir`, `assembly_name`, `ensembl_species_name`, and `geneset_version`. An additional `assembly_accession` column can be provided too.",
+                    "help_text": "The file has to be a comma-separated file with six columns, and a header row. The columns names must be `species_dir`, `assembly_name`, `ensembl_species_name`, `annotation_method`, and `geneset_version`. An additional `assembly_accession` column can be provided too.",
                     "fa_icon": "fas fa-file-csv"
                 },
                 "ftp_root": {

--- a/subworkflows/local/download.nf
+++ b/subworkflows/local/download.nf
@@ -15,20 +15,42 @@ workflow DOWNLOAD {
     ch_versions = Channel.empty()
 
     ENSEMBL_GENESET_DOWNLOAD (
-        annotation_params.map { [
-            // meta
-            [
-                assembly_accession: it[2],
-                geneset_version: it[4],
-                method: it[3],
-                outdir: it[0],
-            ],
-            // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/braker/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-cdna.fa.gz
-            // ftp_path
-            [params.ftp_root, it[1], it[2], it[3], "geneset", it[4]].join("/"),
-            // remote_filename_stem
-            it[1] + "-" + it[2] + "-" + it[4],
-        ] },
+        annotation_params.map {
+
+            species_dir,
+            ensembl_species_name,
+            assembly_accession,
+            annotation_method,
+            geneset_version
+
+            -> [
+                // meta
+                [
+                    assembly_accession: assembly_accession,
+                    geneset_version: geneset_version,
+                    method: annotation_method,
+                    outdir: species_dir,
+                ],
+
+                // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/braker/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-cdna.fa.gz
+                // ftp_path
+                [
+                    params.ftp_root,
+                    ensembl_species_name,
+                    assembly_accession,
+                    annotation_method,
+                    "geneset",
+                    geneset_version,
+                ].join("/"),
+
+                // remote_filename_stem
+                [
+                    ensembl_species_name,
+                    assembly_accession,
+                    geneset_version,
+                ].join("-"),
+            ]
+        },
     )
     ch_versions         = ch_versions.mix(ENSEMBL_GENESET_DOWNLOAD.out.versions.first())
 
@@ -39,20 +61,20 @@ workflow DOWNLOAD {
         .mix( ENSEMBL_GENESET_DOWNLOAD.out.cds.map  { it + ["cds"] }  )
         .mix( ENSEMBL_GENESET_DOWNLOAD.out.pep.map  { it + ["pep"] }  )
         // Add `id` to meta
-        .map { [
-            it[0] + [
-                id: [it[0].assembly_accession, it[0].method, it[0].geneset_version, it[2]].join("."),
+        .map { meta, fasta, type -> [
+            meta + [
+                id: [meta.assembly_accession, meta.method, meta.geneset_version, type].join("."),
             ],
-            it[1]
+            fasta,
         ] }
 
     // tuple(meta,gff) at this stage
-    ch_gff = ENSEMBL_GENESET_DOWNLOAD.out.gff.map { [
+    ch_gff = ENSEMBL_GENESET_DOWNLOAD.out.gff.map { meta, gff -> [
                 // Like above, add meta.id
-                it[0] + [
-                    id: [it[0].assembly_accession, it[0].method, it[0].geneset_version].join("."),
+                meta + [
+                    id: [meta.assembly_accession, meta.method, meta.geneset_version].join("."),
                 ],
-                it[1]
+                gff,
             ] }
 
 

--- a/subworkflows/local/download.nf
+++ b/subworkflows/local/download.nf
@@ -8,7 +8,7 @@ include { ENSEMBL_GENESET_DOWNLOAD      } from '../../modules/local/ensembl_gene
 workflow DOWNLOAD {
 
     take:
-    annotation_params         // tuple(analysis_dir, ensembl_species_name, assembly_accession, geneset_version)
+    annotation_params         // tuple(analysis_dir, ensembl_species_name, assembly_accession, annotation_method, geneset_version)
 
 
     main:
@@ -19,43 +19,40 @@ workflow DOWNLOAD {
             // meta
             [
                 assembly_accession: it[2],
-                geneset_version: it[3],
+                geneset_version: it[4],
+                method: it[3],
                 outdir: it[0],
             ],
-            // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-cdna.fa.gz
+            // e.g. https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/braker/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-cdna.fa.gz
             // ftp_path
-            params.ftp_root + "/" + it[1] + "/" + it[2] + "/geneset/" + it[3],
+            [params.ftp_root, it[1], it[2], it[3], "geneset", it[4]].join("/"),
             // remote_filename_stem
-            it[1] + "-" + it[2] + "-" + it[3],
+            it[1] + "-" + it[2] + "-" + it[4],
         ] },
     )
     ch_versions         = ch_versions.mix(ENSEMBL_GENESET_DOWNLOAD.out.versions.first())
 
-    // Note: ideally ENSEMBL_GENESET_DOWNLOAD should set meta right, but we need the annotation method
-    //       which is only available once the download has happened
+    // Set meta.id
     ch_all_gene_fasta   = Channel.empty()
-        // All three channels are tuple(meta,annotation_method,fasta). Extend the tuple with the sequence type
+        // All three channels are tuple(meta,fasta). Extend the tuple with the sequence type
         .mix( ENSEMBL_GENESET_DOWNLOAD.out.cdna.map { it + ["cdna"] } )
         .mix( ENSEMBL_GENESET_DOWNLOAD.out.cds.map  { it + ["cds"] }  )
         .mix( ENSEMBL_GENESET_DOWNLOAD.out.pep.map  { it + ["pep"] }  )
-        // Add `id` and `method` to meta
+        // Add `id` to meta
         .map { [
             it[0] + [
-                id: [it[0].assembly_accession, it[1], it[0].geneset_version, it[3]].join("."),
-                method: it[1],
+                id: [it[0].assembly_accession, it[0].method, it[0].geneset_version, it[2]].join("."),
             ],
-            it[2]
+            it[1]
         ] }
 
-    // tuple(meta,annotation_method,gff) at this stage
+    // tuple(meta,gff) at this stage
     ch_gff = ENSEMBL_GENESET_DOWNLOAD.out.gff.map { [
-                // Like above, turn into the regular tuple(meta,file), with `id` and others in meta
+                // Like above, add meta.id
                 it[0] + [
-                    id: [it[0].assembly_accession, it[1], it[0].geneset_version].join("."),
-                    method: it[1],
-                    geneset_version: it[0].geneset_version,
+                    id: [it[0].assembly_accession, it[0].method, it[0].geneset_version].join("."),
                 ],
-                it[2]
+                it[1]
             ] }
 
 

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -9,6 +9,7 @@ workflow PARAMS_CHECK {
     take:
     samplesheet  // file
     cli_params   // tuple, see below
+    outdir       // file output directory
 
 
     main:
@@ -28,7 +29,7 @@ workflow PARAMS_CHECK {
             }
             // Convert to tuple, as required by the download subworkflow
             .map { [
-                "${it["species_dir"]}/analysis/${it["assembly_name"]}",
+                (it["species_dir"].startsWith("/") ? "" : outdir + "/") + "${it["species_dir"]}/analysis/${it["assembly_name"]}",
                 it["ensembl_species_name"],
                 it["assembly_accession"],
                 it["annotation_method"],

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -41,7 +41,7 @@ workflow PARAMS_CHECK {
 
     } else {
         // Add the other input channel in, as it's expected to have all the parameters in the right order
-        ch_inputs = ch_inputs.mix(cli_params)
+        ch_inputs = ch_inputs.mix(cli_params.map { [outdir] + it } )
     }
 
     emit:

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -18,7 +18,7 @@ workflow PARAMS_CHECK {
     if (samplesheet) {
         SAMPLESHEET_CHECK ( file(samplesheet, checkIfExists: true) )
             .csv
-            // Provides species_dir, assembly_name, assembly_accession (optional), ensembl_species_name, and geneset_version
+            // Provides species_dir, assembly_name, assembly_accession (optional), ensembl_species_name, annotation_method, and geneset_version
             .splitCsv ( header:true, sep:',' )
             .map {
                 // If assembly_accession is missing, load the accession number from file, following the Tree of Life directory structure
@@ -31,6 +31,7 @@ workflow PARAMS_CHECK {
                 "${it["species_dir"]}/analysis/${it["assembly_name"]}",
                 it["ensembl_species_name"],
                 it["assembly_accession"],
+                it["annotation_method"],
                 it["geneset_version"],
             ] }
             .set { ch_inputs }
@@ -43,7 +44,7 @@ workflow PARAMS_CHECK {
     }
 
     emit:
-    ensembl_params  = ch_inputs        // tuple(analysis_dir, ensembl_species_name, assembly_accession, geneset_version)
+    ensembl_params  = ch_inputs        // tuple(analysis_dir, ensembl_species_name, assembly_accession, annotation_method, geneset_version)
     versions        = ch_versions      // channel: versions.yml
 }
 

--- a/workflows/ensemblgenedownload.nf
+++ b/workflows/ensemblgenedownload.nf
@@ -48,13 +48,13 @@ workflow ENSEMBLGENEDOWNLOAD {
         params.input,
         Channel.of(
             [
-                params.outdir,
                 params.ensembl_species_name,
                 params.assembly_accession,
                 params.annotation_method,
                 params.geneset_version,
             ]
         ),
+        params.outdir,
     )
     ch_versions         = ch_versions.mix(PARAMS_CHECK.out.versions)
 

--- a/workflows/ensemblgenedownload.nf
+++ b/workflows/ensemblgenedownload.nf
@@ -51,6 +51,7 @@ workflow ENSEMBLGENEDOWNLOAD {
                 params.outdir,
                 params.ensembl_species_name,
                 params.assembly_accession,
+                params.annotation_method,
                 params.geneset_version,
             ]
         ),


### PR DESCRIPTION
https://jira.sanger.ac.uk/browse/TOLIT-954

Ensembl have now introduced an extra directory level on their FTP to indicate the annotation method: https://www.ensembl.info/2022/11/08/updates-to-the-ensembl-rapid-release-ftp-site/

The PR below adds an extra parameter (command-line + sample-sheet) for the annotation method. It uses that to build the correct FTP URL, but also name the output directory. Previously I was finding the annotation method from the ID format of the genes, which had issues: I only supported Braker and Ensembl, not the other sources they have (flybase & co). Another change is that to align with Ensembl, I would now name our directories `braker` rather than `braker2`.

Then, based on feedback from @gq1 when testing Tower, I've changed the way relative paths given in the sample-sheet are interpreted. Instead of being resolved under the current directory, they're now made relative to `--outdir`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/ensemblgenedownload/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
